### PR TITLE
[Refactor] enforcing strict Axon runtime RPC memory ownership using UcxBuffer.

### DIFF
--- a/axon/python/BUILD.bazel
+++ b/axon/python/BUILD.bazel
@@ -569,7 +569,7 @@ genrule(
 )
 
 # Python wrapper library that exposes the C++ extension module
-# This creates a py_library that can be imported as 'axon_runtime'
+# This creates a py_library that can be imported as 'axon'
 py_library(
     name = "axon_python",
     srcs = [

--- a/axon/python/src/bindings_runtime_wrapper.cpp
+++ b/axon/python/src/bindings_runtime_wrapper.cpp
@@ -72,73 +72,33 @@ PythonAsyncFunctionWrapper::operator()(
   return FunctionImpl(params, payload);
 }
 
-template <typename PayloadT>
 nb::object PythonAsyncFunctionWrapper::ConvertSingleParamToPython(
-  size_t flat_tensor_idx, size_t tensor_param_idx,
-  rpc::utils::TensorMeta&& meta, const PayloadT& payload) const {
-  // Check if we have a cached Python object from custom memory policy
-  // This avoids reconstructing the object from UcxBuffer/UcxBufferVec
-  if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
-    auto cached_obj = TryGetCustomBuffer(payload.data());
-    if (!cached_obj.is_none()) {
-      return cached_obj;
-    }
-  } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
-    const auto& buffers = payload.buffers();
-    if (flat_tensor_idx < buffers.size()) {
-      auto cached_obj = TryGetCustomBuffer(buffers[flat_tensor_idx].data);
-      if (!cached_obj.is_none()) {
-        return cached_obj;
-      }
-    }
+  size_t tensor_param_idx, rpc::utils::TensorMeta&& meta,
+  ucxx::UcxBuffer&& buffer) const {
+  auto cached_obj = TryGetCustomBuffer(buffer.data());
+  if (!cached_obj.is_none()) {
+    return cached_obj;
   }
 
-  nb::object dltensor_capsule;
+  nb::object dltensor_capsule =
+    TensorMetaToDlpack(std::move(meta), std::move(buffer));
 
-  if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
-    // Create a non-owning UcxBuffer view for this tensor
-    ucxx::UcxBuffer non_owning_buffer(
-      self.GetMemoryResourceManager(), payload.type(), payload.data(),
-      payload.size(), payload.mem_h(), false);
-    dltensor_capsule =
-      TensorMetaToDlpack(std::move(meta), std::move(non_owning_buffer));
-  } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
-    const auto& buffers = payload.buffers();
-    if (flat_tensor_idx >= buffers.size()) {
-      throw std::runtime_error("Tensor index out of range in UcxBufferVec");
-    }
-
-    const auto& buffer = buffers[flat_tensor_idx];
-    ucxx::UcxBuffer non_owning_buffer(
-      self.GetMemoryResourceManager(), payload.type(), buffer.data, buffer.size,
-      payload.mem_h(), false);
-
-    dltensor_capsule =
-      TensorMetaToDlpack(std::move(meta), std::move(non_owning_buffer));
-  } else {
-    throw std::runtime_error(
-      "TensorMeta parameter requires UcxBuffer or UcxBufferVec payload");
-  }
-
-  // Use saved from_dlpack_fn method to convert to user-expected type
   if (tensor_param_idx < tensor_param_from_dlpack.size()) {
     const auto& from_dlpack_ref = tensor_param_from_dlpack[tensor_param_idx];
     if (from_dlpack_ref) {
       nb::object from_dlpack_fn = from_dlpack_ref.get();
       if (!from_dlpack_fn.is_none()) {
-        // Call type.from_dlpack_fn(dltensor_capsule) to get the correct type
         return from_dlpack_fn(dltensor_capsule);
       }
     }
   }
 
-  // Fallback: return raw dltensor capsule if no from_dlpack_fn is available
   return dltensor_capsule;
 }
 
 template <typename PayloadT>
 nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython(
-  data::vector<rpc::ParamMeta>& params, const PayloadT& payload) const {
+  data::vector<rpc::ParamMeta>& params, PayloadT& payload) const {
   nb::list py_args;
 
   const size_t num_params = param_types.size();
@@ -207,6 +167,18 @@ nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython(
   size_t tensor_param_idx = 0;
   size_t non_tensor_idx = 0;
 
+  std::vector<ucxx::UcxBuffer> extracted_buffers;
+  if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
+    if (payload.size() > 0) {
+      // By calling ExtractBuffers(), we take ownership of the individual
+      // UcxBuffer instances. This is crucial for avoiding shared lifetime
+      // constraints: each resulting DLPack capsule effectively owns its
+      // independent underlying component, transferring memory management
+      // natively to the Python Garbage Collector.
+      extracted_buffers = std::move(payload).ExtractBuffers();
+    }
+  }
+
   for (size_t i = 0; i < num_params; ++i) {
     const auto& enc = encoded_lookup[i];
     if (enc == NL::NESTED_TENSOR_LIST) {
@@ -230,12 +202,23 @@ nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython(
             throw std::runtime_error(
               "Not enough tensors for nested tensor list");
           }
-          auto py_dlpack = ConvertSingleParamToPython(
-            flat_tensor_idx, tensor_param_idx,
-            std::move(const_cast<rpc::utils::TensorMeta&>(
-              (*tensor_meta_vec_ptr)[flat_tensor_idx])),
-            payload);
-          inner.append(std::move(py_dlpack));
+          if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
+            auto py_dlpack = ConvertSingleParamToPython(
+              tensor_param_idx,
+              std::move(const_cast<rpc::utils::TensorMeta&>(
+                (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+              std::move(payload));
+            inner.append(std::move(py_dlpack));
+          } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
+            auto py_dlpack = ConvertSingleParamToPython(
+              tensor_param_idx,
+              std::move(const_cast<rpc::utils::TensorMeta&>(
+                (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+              std::move(extracted_buffers[flat_tensor_idx]));
+            inner.append(std::move(py_dlpack));
+          } else {
+            throw std::runtime_error("Unexpected payload type for tensor");
+          }
           ++flat_tensor_idx;
         }
         outer.append(std::move(inner));
@@ -264,20 +247,42 @@ nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython(
       // next tensor from the shared stream sequentially.
       if (
         tensor_meta_vec_ptr && flat_tensor_idx < tensor_meta_vec_ptr->size()) {
-        auto py_dlpack = ConvertSingleParamToPython(
-          flat_tensor_idx, tensor_param_idx,
-          std::move(const_cast<rpc::utils::TensorMeta&>(
-            (*tensor_meta_vec_ptr)[flat_tensor_idx])),
-          payload);
-        py_args.append(py_dlpack);
+        if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
+          auto py_dlpack = ConvertSingleParamToPython(
+            tensor_param_idx,
+            std::move(const_cast<rpc::utils::TensorMeta&>(
+              (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+            std::move(payload));
+          py_args.append(std::move(py_dlpack));
+        } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
+          auto py_dlpack = ConvertSingleParamToPython(
+            tensor_param_idx,
+            std::move(const_cast<rpc::utils::TensorMeta&>(
+              (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+            std::move(extracted_buffers[flat_tensor_idx]));
+          py_args.append(std::move(py_dlpack));
+        } else {
+          throw std::runtime_error("Unexpected payload type for tensor");
+        }
         ++flat_tensor_idx;
       } else if (single_tensor_meta_ptr && flat_tensor_idx == 0) {
-        auto py_dlpack = ConvertSingleParamToPython(
-          flat_tensor_idx, tensor_param_idx,
-          std::move(
-            const_cast<rpc::utils::TensorMeta&>(*single_tensor_meta_ptr)),
-          payload);
-        py_args.append(py_dlpack);
+        if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
+          auto py_dlpack = ConvertSingleParamToPython(
+            tensor_param_idx,
+            std::move(
+              const_cast<rpc::utils::TensorMeta&>(*single_tensor_meta_ptr)),
+            std::move(payload));
+          py_args.append(std::move(py_dlpack));
+        } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
+          auto py_dlpack = ConvertSingleParamToPython(
+            tensor_param_idx,
+            std::move(
+              const_cast<rpc::utils::TensorMeta&>(*single_tensor_meta_ptr)),
+            std::move(extracted_buffers[flat_tensor_idx]));
+          py_args.append(std::move(py_dlpack));
+        } else {
+          throw std::runtime_error("Unexpected payload type for tensor");
+        }
         ++flat_tensor_idx;
       } else {
         throw std::runtime_error(
@@ -290,12 +295,23 @@ nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython(
       nb::list tensor_list;
       if (tensor_meta_vec_ptr) {
         while (flat_tensor_idx < tensor_meta_vec_ptr->size()) {
-          auto py_dlpack = ConvertSingleParamToPython(
-            flat_tensor_idx, tensor_param_idx,
-            std::move(const_cast<rpc::utils::TensorMeta&>(
-              (*tensor_meta_vec_ptr)[flat_tensor_idx])),
-            payload);
-          tensor_list.append(std::move(py_dlpack));
+          if constexpr (std::is_same_v<PayloadT, ucxx::UcxBuffer>) {
+            auto py_dlpack = ConvertSingleParamToPython(
+              tensor_param_idx,
+              std::move(const_cast<rpc::utils::TensorMeta&>(
+                (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+              std::move(payload));
+            tensor_list.append(std::move(py_dlpack));
+          } else if constexpr (std::is_same_v<PayloadT, ucxx::UcxBufferVec>) {
+            auto py_dlpack = ConvertSingleParamToPython(
+              tensor_param_idx,
+              std::move(const_cast<rpc::utils::TensorMeta&>(
+                (*tensor_meta_vec_ptr)[flat_tensor_idx])),
+              std::move(extracted_buffers[flat_tensor_idx]));
+            tensor_list.append(std::move(py_dlpack));
+          } else {
+            throw std::runtime_error("Unexpected payload type for tensor");
+          }
           ++flat_tensor_idx;
         }
       }
@@ -598,26 +614,19 @@ PythonAsyncFunctionWrapper::FunctionImpl(
         [this, owned_params = std::move(owned_params),
          owned_payload = std::move(owned_payload), &receiver]() mutable {
           try {
-            // Use non-const refs to allow moving TensorMeta for zero-copy
             auto& params = owned_params;
-            const auto& payload = owned_payload;
-            auto py_args = ConvertParamsToPython(params, payload);
-
             nb::object py_coro;
+
             if (!tensor_param_indices.empty()) {
-              // Normal mode: tensor params are already parsed and in py_args
-              // via ConvertParamsToPython which uses
-              // ConvertSingleParamToPython
+              auto py_args = ConvertParamsToPython(params, owned_payload);
               py_coro = this->py_callable(*py_args);
             } else {
-              // Raw mode (register_function_raw): no tensor params parsed,
-              // pass the payload directly as UcxBuffer/UcxBufferVec
+              auto py_args = ConvertParamsToPython(params, owned_payload);
               if constexpr (std::is_same_v<PayloadT, std::monostate>) {
                 py_coro = this->py_callable(*py_args);
               } else {
-                // Pass UcxBuffer or UcxBufferVec directly - they are already
-                // registered with nanobind in bindings_types.cpp
-                py_coro = this->py_callable(*py_args, nb::cast(payload));
+                py_coro = this->py_callable(
+                  *py_args, nb::cast(std::move(owned_payload)));
               }
             }
 
@@ -626,19 +635,9 @@ PythonAsyncFunctionWrapper::FunctionImpl(
             nb::object future = asyncio.attr("ensure_future")(task);
 
             auto py_callback = CreatePythonResultCallback(receiver);
-
-            // CRITICAL FIX: Use shared_ptr to extend payload lifetime until
-            // the Python async task completes. Without this, the payload
-            // would be destroyed when the TaskFacade lambda exits, but the
-            // Python task may not have executed yet. We use shared_ptr
-            // because nanobind::cpp_function requires a const callable, and
-            // we need to move the payload into shared ownership.
-            auto payload_keeper =
-              std::make_shared<PayloadT>(std::move(owned_payload));
-
-            future.attr("add_done_callback")(nb::cpp_function(
-              [callback = std::move(py_callback),
-               payload_keeper](nb::object fut) { callback(fut); }));
+            future.attr("add_done_callback")(
+              nb::cpp_function([callback = std::move(py_callback)](
+                                 nb::object fut) { callback(fut); }));
           } catch (const nb::python_error& e) {
             receiver.set_error(std::make_exception_ptr(std::runtime_error(
               "Failed to call Python async function: "
@@ -651,20 +650,12 @@ PythonAsyncFunctionWrapper::FunctionImpl(
 }
 
 // Explicit template instantiations
-template nb::object
-PythonAsyncFunctionWrapper::ConvertSingleParamToPython<ucxx::UcxBuffer>(
-  size_t, size_t, rpc::utils::TensorMeta&&, const ucxx::UcxBuffer&) const;
-template nb::object
-PythonAsyncFunctionWrapper::ConvertSingleParamToPython<ucxx::UcxBufferVec>(
-  size_t, size_t, rpc::utils::TensorMeta&&, const ucxx::UcxBufferVec&) const;
-
 template nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython<
-  std::monostate>(data::vector<rpc::ParamMeta>&, const std::monostate&) const;
+  std::monostate>(data::vector<rpc::ParamMeta>&, std::monostate&) const;
 template nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython<
-  ucxx::UcxBuffer>(data::vector<rpc::ParamMeta>&, const ucxx::UcxBuffer&) const;
-template nb::list
-PythonAsyncFunctionWrapper::ConvertParamsToPython<ucxx::UcxBufferVec>(
-  data::vector<rpc::ParamMeta>&, const ucxx::UcxBufferVec&) const;
+  ucxx::UcxBuffer>(data::vector<rpc::ParamMeta>&, ucxx::UcxBuffer&) const;
+template nb::list PythonAsyncFunctionWrapper::ConvertParamsToPython<
+  ucxx::UcxBufferVec>(data::vector<rpc::ParamMeta>&, ucxx::UcxBufferVec&) const;
 
 template nb::object PythonAsyncFunctionWrapper::ConvertPayloadToPython<
   std::monostate>(std::monostate&&) const;

--- a/axon/python/src/bindings_runtime_wrapper.hpp
+++ b/axon/python/src/bindings_runtime_wrapper.hpp
@@ -87,15 +87,14 @@ struct __attribute__((visibility("hidden"))) PythonAsyncFunctionWrapper {
 
  private:
   // Convert single tensor parameter to Python dlpack object
-  template <typename PayloadT>
   nb::object ConvertSingleParamToPython(
-    size_t flat_tensor_idx, size_t tensor_param_idx,
-    rpc::utils::TensorMeta&& meta, const PayloadT& payload) const;
+    size_t tensor_param_idx, rpc::utils::TensorMeta&& meta,
+    ucxx::UcxBuffer&& buffer) const;
 
   // Convert all parameters to Python objects
   template <typename PayloadT>
   nb::list ConvertParamsToPython(
-    data::vector<rpc::ParamMeta>& params, const PayloadT& payload) const;
+    data::vector<rpc::ParamMeta>& params, PayloadT& payload) const;
 
   // Convert payload to Python object (for non-tensor payloads)
   template <typename PayloadT>

--- a/axon/python/src/dlpack_helpers.cpp
+++ b/axon/python/src/dlpack_helpers.cpp
@@ -394,138 +394,87 @@ ucxx::UcxBufferVec DlpackToUcxBufferVec(
     [owners = std::move(owners)](void*) {});
 }
 
-// Context struct for TensorMetaToDlpack ownership management
 struct TensorDlpackContext {
   std::unique_ptr<axon::utils::TensorBase> tensor;
-  std::unique_ptr<ucxx::UcxBuffer> buffer;
+  std::shared_ptr<void> data_keeper;
 
   TensorDlpackContext(
-    std::unique_ptr<axon::utils::TensorBase> t,
-    std::unique_ptr<ucxx::UcxBuffer> b)
-    : tensor(std::move(t)), buffer(std::move(b)) {}
+    std::unique_ptr<axon::utils::TensorBase> t, std::shared_ptr<void> keeper)
+    : tensor(std::move(t)), data_keeper(std::move(keeper)) {}
 };
 
 nb::object TensorMetaToDlpack(
   rpc::utils::TensorMeta&& meta, ucxx::UcxBuffer&& buffer) {
-  // Create TensorBase from TensorMeta and UcxBuffer
+  auto owned = std::make_shared<ucxx::UcxBuffer>(std::move(buffer), false);
+  DLDevice device = UcxMemoryTypeToDlDevice(owned->type());
   auto tensor = std::make_unique<axon::utils::TensorBase>();
-  tensor->assign(std::move(meta), buffer.data());
+  tensor->assign(std::move(meta), owned->data());
+  tensor->device = device;
 
-  // Override the device with the ACTUAL buffer memory type.
-  // The TensorMeta comes from the sender and may indicate CUDA, but when
-  // using AlwaysOnHostPolicy, the buffer is actually in host memory.
-  // We MUST use the buffer's memory type to ensure the DLPack device
-  // correctly reflects where the data actually resides.
-  DLDevice actual_device = UcxMemoryTypeToDlDevice(buffer.type());
-  tensor->device = actual_device;
-
-  // Create DLManagedTensor for Python
   DLManagedTensor* dlm_tensor = new DLManagedTensor;
   dlm_tensor->dl_tensor.data = tensor->data;
-  dlm_tensor->dl_tensor.device = tensor->device;
+  dlm_tensor->dl_tensor.device = device;
   dlm_tensor->dl_tensor.ndim = tensor->ndim;
   dlm_tensor->dl_tensor.dtype = tensor->dtype;
   dlm_tensor->dl_tensor.shape = tensor->shape;
   dlm_tensor->dl_tensor.strides = tensor->strides;
   dlm_tensor->dl_tensor.byte_offset = tensor->byte_offset;
-
-  // Use unique_ptr-based context for ownership management
-  // IMPORTANT: Set own_buffer = false to prevent UcxBuffer::~UcxBuffer
-  // from calling deallocate() on UcxMemoryResourceManager, which may have been
-  // destroyed before this DLPack capsule (lifetime is controlled by Python GC).
-  auto owned_buffer =
-    std::make_unique<ucxx::UcxBuffer>(std::move(buffer), false);
-
-  dlm_tensor->manager_ctx =
-    new TensorDlpackContext(std::move(tensor), std::move(owned_buffer));
+  dlm_tensor->manager_ctx = new TensorDlpackContext(
+    std::move(tensor), std::static_pointer_cast<void>(std::move(owned)));
   dlm_tensor->deleter = [](DLManagedTensor* self) {
     delete static_cast<TensorDlpackContext*>(self->manager_ctx);
     delete self;
   };
 
-  // Create PyCapsule with safe destructor that handles consumed capsules
   nb::object capsule = nb::steal<nb::object>(
     PyCapsule_New(dlm_tensor, "dltensor", SafeDlpackCapsuleDestructor));
-
-  // Return wrapped in DLPackCapsuleWrapper for from_dlpack compatibility
-  return nb::cast(DLPackCapsuleWrapper(std::move(capsule), actual_device));
+  return nb::cast(DLPackCapsuleWrapper(std::move(capsule), device));
 }
-
-// Context struct for TensorMetaVecToDlpack ownership management
-// Uses shared_ptr for UcxBufferVec because:
-// 1. UcxBufferVec may have a single backing_buffer_ that's a contiguous
-// allocation
-// 2. Individual buffers are views into the backing buffer, can't be freed
-// independently
-// 3. All DLPack objects must keep the backing memory alive until ALL are done
-struct TensorVecDlpackContext {
-  std::unique_ptr<axon::utils::TensorBase> tensor;
-  std::shared_ptr<ucxx::UcxBufferVec> buffer_vec;
-
-  TensorVecDlpackContext(
-    std::unique_ptr<axon::utils::TensorBase> t,
-    std::shared_ptr<ucxx::UcxBufferVec> bv)
-    : tensor(std::move(t)), buffer_vec(std::move(bv)) {}
-};
 
 nb::list TensorMetaVecToDlpack(
   cista::offset::vector<rpc::utils::TensorMeta>&& meta_vec,
   ucxx::UcxBufferVec&& buffer_vec) {
-  nb::list result;
   if (meta_vec.size() != buffer_vec.size()) {
     throw std::runtime_error("TensorMetaVec and UcxBufferVec size mismatch");
   }
+  nb::list result;
 
-  // Get the actual memory type from buffer_vec BEFORE moving it.
-  // This ensures we use the receiver's actual memory location, not the
-  // sender's.
-  DLDevice actual_device = UcxMemoryTypeToDlDevice(buffer_vec.type());
+  if (buffer_vec.has_backing_buffer()) {
+    auto shared_buffer_vec =
+      std::make_shared<ucxx::UcxBufferVec>(std::move(buffer_vec));
+    ucx_memory_type_t mem_type = shared_buffer_vec->type();
+    DLDevice device = UcxMemoryTypeToDlDevice(mem_type);
 
-  // Use shared_ptr to allow multiple capsules to share the same buffer_vec
-  // IMPORTANT: Set own_buffer = false to prevent UcxBufferVec::~UcxBufferVec
-  // from calling deallocate() on UcxMemoryResourceManager, which may have been
-  // destroyed before this DLPack capsule (lifetime is controlled by Python GC).
-  // The actual buffer memory will be freed when the unifex sender chain
-  // completes.
-  auto shared_buffer_vec =
-    std::make_shared<ucxx::UcxBufferVec>(std::move(buffer_vec), false);
+    for (size_t i = 0; i < meta_vec.size(); ++i) {
+      auto tensor = std::make_unique<axon::utils::TensorBase>();
+      tensor->assign(std::move(meta_vec[i]), (*shared_buffer_vec)[i].data);
+      tensor->device = device;
 
-  // Get buffers from UcxBufferVec
-  const auto& buffers = shared_buffer_vec->buffers();
-  for (size_t i = 0; i < meta_vec.size(); ++i) {
-    auto& meta = meta_vec[i];
-    const auto& buffer = buffers[i];
+      DLManagedTensor* dlm_tensor = new DLManagedTensor;
+      dlm_tensor->dl_tensor.data = tensor->data;
+      dlm_tensor->dl_tensor.device = device;
+      dlm_tensor->dl_tensor.ndim = tensor->ndim;
+      dlm_tensor->dl_tensor.dtype = tensor->dtype;
+      dlm_tensor->dl_tensor.shape = tensor->shape;
+      dlm_tensor->dl_tensor.strides = tensor->strides;
+      dlm_tensor->dl_tensor.byte_offset = tensor->byte_offset;
+      dlm_tensor->manager_ctx =
+        new TensorDlpackContext(std::move(tensor), shared_buffer_vec);
+      dlm_tensor->deleter = [](DLManagedTensor* self) {
+        delete static_cast<TensorDlpackContext*>(self->manager_ctx);
+        delete self;
+      };
 
-    // Create TensorBase from TensorMeta and buffer data
-    auto tensor = std::make_unique<axon::utils::TensorBase>();
-    tensor->assign(std::move(meta), buffer.data);
-
-    // Override device with actual buffer memory type
-    tensor->device = actual_device;
-
-    // Create DLManagedTensor for Python (zero-copy)
-    DLManagedTensor* dlm_tensor = new DLManagedTensor;
-    dlm_tensor->dl_tensor.data = tensor->data;
-    dlm_tensor->dl_tensor.device = actual_device;
-    dlm_tensor->dl_tensor.ndim = tensor->ndim;
-    dlm_tensor->dl_tensor.dtype = tensor->dtype;
-    dlm_tensor->dl_tensor.shape = tensor->shape;
-    dlm_tensor->dl_tensor.strides = tensor->strides;
-    dlm_tensor->dl_tensor.byte_offset = tensor->byte_offset;
-
-    // Use named context struct for ownership management
-    dlm_tensor->manager_ctx =
-      new TensorVecDlpackContext(std::move(tensor), shared_buffer_vec);
-    dlm_tensor->deleter = [](DLManagedTensor* self) {
-      delete static_cast<TensorVecDlpackContext*>(self->manager_ctx);
-      delete self;
-    };
-
-    // Wrap in DLPackCapsuleWrapper for from_dlpack compatibility
-    nb::object capsule = nb::steal<nb::object>(
-      PyCapsule_New(dlm_tensor, "dltensor", SafeDlpackCapsuleDestructor));
-    result.append(
-      nb::cast(DLPackCapsuleWrapper(std::move(capsule), actual_device)));
+      nb::object capsule = nb::steal<nb::object>(
+        PyCapsule_New(dlm_tensor, "dltensor", SafeDlpackCapsuleDestructor));
+      result.append(nb::cast(DLPackCapsuleWrapper(std::move(capsule), device)));
+    }
+  } else {
+    auto bufs = std::move(buffer_vec).ExtractBuffers();
+    for (size_t i = 0; i < meta_vec.size(); ++i) {
+      result.append(
+        TensorMetaToDlpack(std::move(meta_vec[i]), std::move(bufs[i])));
+    }
   }
   return result;
 }

--- a/axon/python/src/dlpack_helpers.hpp
+++ b/axon/python/src/dlpack_helpers.hpp
@@ -195,7 +195,6 @@ ucxx::UcxBufferVec DlpackToUcxBufferVec(
   ucx_memory_type_t mem_type,
   std::reference_wrapper<ucxx::UcxMemoryResourceManager> mr);
 
-// Convert TensorMeta + UcxBuffer to dlpack object (single tensor)
 nb::object TensorMetaToDlpack(
   rpc::utils::TensorMeta&& meta, ucxx::UcxBuffer&& buffer);
 

--- a/axon/python/tests/test_numpy_rpc.py
+++ b/axon/python/tests/test_numpy_rpc.py
@@ -432,5 +432,68 @@ async def test_nested_bool():
             pass
 
 
+_stored_input_tensor = None
+
+
+async def _store_input_func(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    global _stored_input_tensor
+    _stored_input_tensor = a
+    return a + b
+
+
+@pytest.mark.asyncio
+async def test_input_tensor_lifetime_safety():
+    """Input tensors must remain valid when stored beyond the coroutine lifetime.
+
+    The server function captures an input tensor into a global. With the old
+    non-owning UcxBuffer design, the backing UCX buffer was freed when the
+    payload_keeper callback fired (after coroutine completion), causing a
+    use-after-free. With the shared_ptr<void> keeper design the tensor keeps
+    the buffer alive for as long as any Python object references it.
+    """
+    global _stored_input_tensor
+    _stored_input_tensor = None
+
+    server = axon.AxonRuntime("test_lifetime_server")
+    server.start()
+    server.register_function(_store_input_func, 200, from_dlpack_fn=np.from_dlpack)
+
+    client = axon.AxonRuntime("test_lifetime_client")
+    client.start_client()
+    await client.connect_endpoint_async(
+        server.get_local_address(), "test_lifetime_server"
+    )
+
+    try:
+        a = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        b = np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64)
+
+        result = await client.invoke(
+            a,
+            b,
+            worker_name="test_lifetime_server",
+            session_id=0,
+            function=200,
+            from_dlpack_fn=np.from_dlpack,
+        )
+
+        # Yield to the event loop so the done_callback fires and
+        # payload_keeper in the callback lambda is released.
+        await asyncio.sleep(0)
+
+        # _stored_input_tensor must still point to valid memory even after
+        # the callback released payload_keeper.
+        assert _stored_input_tensor is not None
+        np.testing.assert_array_equal(_stored_input_tensor, a)
+        np.testing.assert_array_equal(result, a + b)
+    finally:
+        _stored_input_tensor = None
+        try:
+            client.stop()
+            server.stop()
+        except Exception:
+            pass
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/ucx_context/ucx_context_data.hpp
+++ b/ucx_context/ucx_context_data.hpp
@@ -594,6 +594,27 @@ class UcxBufferVec {
    */
   bool own_buffer() const { return own_buffer_; }
 
+  std::vector<UcxBuffer> ExtractBuffers() && {
+    if (backing_buffer_ != nullptr) {
+      throw std::logic_error(
+        "ExtractBuffers() requires independently-allocated UcxBufferVec");
+    }
+    std::vector<UcxBuffer> result;
+    result.reserve(buffers_.size());
+    for (auto& buf : buffers_) {
+      result.emplace_back(
+        mr_, type_, buf, mem_h_, own_buffer_, ucp_release_fn_);
+    }
+    own_buffer_ = false;
+    return result;
+  }
+
+  /**
+   * @brief Checks if the buffer vector has a backing buffer.
+   * @return True if there is a backing buffer, false otherwise.
+   */
+  bool has_backing_buffer() const { return backing_buffer_ != nullptr; }
+
  private:
   explicit UcxBufferVec(
     std::reference_wrapper<UcxMemoryResourceManager> mr, ucx_memory_type_t type,


### PR DESCRIPTION
- Eliminated shared `payload_keeper` dependency entirely in `ConvertParamsToPython` and `ConvertSingleParamToPython`
- Re-architected mapping of payload sizes ensuring lifetime granularity is deferred correctly to Python GC
- Subsumed payload lifecycle management utilizing `.ExtractBuffers()` to pass independent underlying DLPack capsules without artificial refcounting
- Refactored `FunctionImpl` memory bindings avoiding `py_dlpack` variable scope leaks
- Cleaned up dangling template definitions for payload converters

@Florentino-Ding has reviewed it #5 .