### PR TITLE
[Fix] Fix UCX buffer ownership and UcxMemoryResourceManager lifetime management

### DIFF
--- a/axon/python/BUILD.bazel
+++ b/axon/python/BUILD.bazel
@@ -469,6 +469,7 @@ cc_library(
         {"//conditions:default": ["@platforms//:incompatible"]},
     ),
     deps = [
+        ":bindings_memory_resource",
         ":bindings_runtime_helpers",
         ":bindings_runtime_wrapper",
         ":dlpack_helpers",
@@ -500,6 +501,21 @@ copy_to_dir(
 )
 
 cc_library(
+    name = "bindings_memory_resource",
+    srcs = ["src/bindings_memory_resource.cpp"],
+    hdrs = ["src/bindings_memory_resource.hpp"],
+    target_compatible_with = select(
+        {":is_cpp" + v: [] for v in SUPPORTED_CPP_STANDARDS} |
+        {"//conditions:default": ["@platforms//:incompatible"]},
+    ),
+    deps = [
+        "@execution-ucx//ucx_context:ucx_context_data_lib",
+        "@nanobind",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
     name = "axon_python_entry",
     srcs = ["src/axon_python.cpp"],
     target_compatible_with = select(
@@ -508,6 +524,7 @@ cc_library(
     ),
     deps = [
         ":bindings_enums",
+        ":bindings_memory_resource",
         ":bindings_runtime",
         ":bindings_types",
         "@nanobind",
@@ -537,6 +554,7 @@ cc_binary(
         ":async_bridge",
         ":axon_python_entry",
         ":bindings_enums",
+        ":bindings_memory_resource",
         ":bindings_runtime",
         ":bindings_runtime_helpers",
         ":bindings_runtime_wrapper",

--- a/axon/python/axon/__init__.py
+++ b/axon/python/axon/__init__.py
@@ -148,12 +148,46 @@ def _find_and_load_module():
 # Load the module
 _module = _find_and_load_module()
 
+# Create a package-level DefaultUcxMemoryResourceManager instance.
+# Its lifetime matches the package, outliving any AxonRuntime or tensor objects,
+# which prevents the underlying memory from being freed while tensors still exist.
+_default_resource_manager = None
+if _module and hasattr(_module, "DefaultUcxMemoryResourceManager"):
+    _default_resource_manager = _module.DefaultUcxMemoryResourceManager()
+
+
+def get_default_resource_manager():
+    """Return the package-level DefaultUcxMemoryResourceManager instance.
+
+    This manager's lifetime is tied to the axon package. Pass it to
+    AxonRuntime to ensure UCX memory buffers are not freed while
+    DLPack tensors derived from them are still alive.
+    """
+    return _default_resource_manager
+
+
 # Re-export everything from the C++ module
 if _module:
     # Copy all attributes from the C++ module to this module's namespace
     for name in dir(_module):
         if not name.startswith("_"):
             setattr(sys.modules[__name__], name, getattr(_module, name))
+
+# Wrap AxonRuntime to auto-inject the global memory manager when none is provided
+_CppAxonRuntime = getattr(sys.modules[__name__], "AxonRuntime", None)
+if _CppAxonRuntime is not None:
+
+    class AxonRuntime(_CppAxonRuntime):
+        def __init__(self, *args, **kwargs):
+            if (
+                not any(isinstance(x, UcxMemoryResourceManager) for x in args)
+                and "resource_manager" not in kwargs
+                and _default_resource_manager is not None
+            ):
+                kwargs["resource_manager"] = _default_resource_manager
+            super().__init__(*args, **kwargs)
+
+    setattr(sys.modules[__name__], "AxonRuntime", AxonRuntime)
 
 # Import and re-export device module
 from .device import (
@@ -171,6 +205,12 @@ from .device import (
 )
 
 __all__ = [
+    # Runtime
+    "AxonRuntime",
+    # Memory resource manager
+    "UcxMemoryResourceManager",
+    "DefaultUcxMemoryResourceManager",
+    "get_default_resource_manager",
     # Device types and classes
     "Device",
     "DeviceType",

--- a/axon/python/src/bindings_memory_resource.cpp
+++ b/axon/python/src/bindings_memory_resource.cpp
@@ -13,27 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <nanobind/nanobind.h>
-
-#include "axon/python/src/bindings_enums.hpp"
 #include "axon/python/src/bindings_memory_resource.hpp"
-#include "axon/python/src/bindings_runtime.hpp"
-#include "axon/python/src/bindings_types.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include "ucx_context/ucx_memory_resource.hpp"
 
 namespace nb = nanobind;
 
-// Forward declarations for bindings
-void RegisterEnums(nb::module_& m);
-void RegisterDefaultResourceManager(nb::module_& m);
-void RegisterTypes(nb::module_& m);
-void RegisterRuntime(nb::module_& m);
+void RegisterDefaultResourceManager(nb::module_& m) {
+  nb::class_<eux::ucxx::UcxMemoryResourceManager>(
+    m, "UcxMemoryResourceManager");
 
-NB_MODULE(axon, m) {
-  m.doc() = "Axon Runtime Python bindings";
-
-  // Register all bindings
-  RegisterEnums(m);
-  RegisterDefaultResourceManager(m);
-  RegisterTypes(m);
-  RegisterRuntime(m);
+  nb::class_<
+    eux::ucxx::DefaultUcxMemoryResourceManager,
+    eux::ucxx::UcxMemoryResourceManager>(m, "DefaultUcxMemoryResourceManager")
+    .def(nb::init<>());
 }

--- a/axon/python/src/bindings_memory_resource.hpp
+++ b/axon/python/src/bindings_memory_resource.hpp
@@ -13,27 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <nanobind/nanobind.h>
+#pragma once
 
-#include "axon/python/src/bindings_enums.hpp"
-#include "axon/python/src/bindings_memory_resource.hpp"
-#include "axon/python/src/bindings_runtime.hpp"
-#include "axon/python/src/bindings_types.hpp"
+#ifndef AXON_PYTHON_BINDINGS_MEMORY_RESOURCE_HPP_
+#define AXON_PYTHON_BINDINGS_MEMORY_RESOURCE_HPP_
+
+#include <nanobind/nanobind.h>
 
 namespace nb = nanobind;
 
-// Forward declarations for bindings
-void RegisterEnums(nb::module_& m);
 void RegisterDefaultResourceManager(nb::module_& m);
-void RegisterTypes(nb::module_& m);
-void RegisterRuntime(nb::module_& m);
 
-NB_MODULE(axon, m) {
-  m.doc() = "Axon Runtime Python bindings";
-
-  // Register all bindings
-  RegisterEnums(m);
-  RegisterDefaultResourceManager(m);
-  RegisterTypes(m);
-  RegisterRuntime(m);
-}
+#endif  // AXON_PYTHON_BINDINGS_MEMORY_RESOURCE_HPP_

--- a/axon/python/src/bindings_runtime.cpp
+++ b/axon/python/src/bindings_runtime.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/vector.h>
@@ -33,6 +34,7 @@ limitations under the License.
 #include <unifex/upon_error.hpp>
 
 #include "axon/axon_runtime.hpp"
+#include "axon/python/src/bindings_memory_resource.hpp"
 #include "axon/python/src/bindings_runtime_helpers.hpp"
 #include "axon/python/src/bindings_runtime_wrapper.hpp"
 #include "axon/python/src/dlpack_helpers.hpp"
@@ -42,6 +44,7 @@ limitations under the License.
 #include "axon/python/src/python_wake_manager.hpp"
 
 #include "ucx_context/ucx_device_context.hpp"
+#include "ucx_context/ucx_memory_resource.hpp"
 
 #if CUDA_ENABLED
 #include <cuda.h>
@@ -99,7 +102,8 @@ void RegisterRuntime(nb::module_& m) {
     "__init__",
     [](
       axon::AxonRuntime* self, const std::string& worker_name,
-      size_t thread_pool_size, nb::object timeout_obj, nb::object device_obj) {
+      size_t thread_pool_size, nb::object timeout_obj, nb::object device_obj,
+      nb::object memory_manager_obj) {
       std::unique_ptr<ucxx::UcxAutoDeviceContext> device_context = nullptr;
 
       if (!device_obj.is_none()) {
@@ -155,14 +159,33 @@ void RegisterRuntime(nb::module_& m) {
         }
       }
 
-      new (self) axon::AxonRuntime(
-        worker_name, thread_pool_size, python::ConvertTimeout(timeout_obj),
-        std::move(device_context));
+      if (!memory_manager_obj.is_none()) {
+        auto* raw =
+          nb::cast<ucxx::UcxMemoryResourceManager*>(memory_manager_obj);
+        nb::object kept_alive = memory_manager_obj;
+        auto mr = std::shared_ptr<ucxx::UcxMemoryResourceManager>(
+          raw, [kept_alive = std::move(kept_alive)](
+                 ucxx::UcxMemoryResourceManager*) mutable {
+            if (!Py_IsInitialized()) {
+              return;
+            }
+            nb::gil_scoped_acquire gil;
+            kept_alive = nb::object{};
+          });
+        new (self) axon::AxonRuntime(
+          std::move(mr), worker_name, thread_pool_size,
+          python::ConvertTimeout(timeout_obj), std::move(device_context));
+      } else {
+        new (self) axon::AxonRuntime(
+          worker_name, thread_pool_size, python::ConvertTimeout(timeout_obj),
+          std::move(device_context));
+      }
     },
     nb::arg("worker_name"),
     nb::arg("thread_pool_size") =
       (std::thread::hardware_concurrency() < 16 ? 4 : 16),
-    nb::arg("timeout") = nb::none(), nb::arg("device") = nb::none());
+    nb::arg("timeout") = nb::none(), nb::arg("device") = nb::none(),
+    nb::arg("resource_manager") = nb::none());
 
   cls.def("__del__", [](axon::AxonRuntime& self) {
     nb::gil_scoped_release release;

--- a/axon/python/src/dlpack_helpers.cpp
+++ b/axon/python/src/dlpack_helpers.cpp
@@ -405,7 +405,7 @@ struct TensorDlpackContext {
 
 nb::object TensorMetaToDlpack(
   rpc::utils::TensorMeta&& meta, ucxx::UcxBuffer&& buffer) {
-  auto owned = std::make_shared<ucxx::UcxBuffer>(std::move(buffer), false);
+  auto owned = std::make_shared<ucxx::UcxBuffer>(std::move(buffer), true);
   DLDevice device = UcxMemoryTypeToDlDevice(owned->type());
   auto tensor = std::make_unique<axon::utils::TensorBase>();
   tensor->assign(std::move(meta), owned->data());

--- a/axon/python/tests/test_numpy_rpc.py
+++ b/axon/python/tests/test_numpy_rpc.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
 import asyncio
+import gc
+import weakref
 from typing import List, Tuple
 import test_utils  # noqa: F401
 import axon
@@ -433,12 +435,37 @@ async def test_nested_bool():
 
 
 _stored_input_tensor = None
+_released_input_tensor = None
+_released_input_tensor_ref = None
 
 
 async def _store_input_func(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     global _stored_input_tensor
     _stored_input_tensor = a
     return a + b
+
+
+async def _store_then_release_input_func(a: np.ndarray) -> int:
+    global _released_input_tensor, _released_input_tensor_ref
+
+    _released_input_tensor = a
+    _released_input_tensor_ref = weakref.ref(a)
+    del a
+
+    await asyncio.sleep(0)
+
+    result = int(np.sum(_released_input_tensor))
+    _released_input_tensor = None
+    return result
+
+
+async def _wait_for_object_release(obj_ref, retries: int = 10):
+    for _ in range(retries):
+        if obj_ref is None or obj_ref() is None:
+            return True
+        gc.collect()
+        await asyncio.sleep(0)
+    return obj_ref() is None
 
 
 @pytest.mark.asyncio
@@ -488,6 +515,52 @@ async def test_input_tensor_lifetime_safety():
         np.testing.assert_array_equal(result, a + b)
     finally:
         _stored_input_tensor = None
+        try:
+            client.stop()
+            server.stop()
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_input_tensor_is_released_after_rpc():
+    """Stored server-side tensor references should be released after RPC."""
+    global _released_input_tensor, _released_input_tensor_ref
+    _released_input_tensor = None
+    _released_input_tensor_ref = None
+
+    server = axon.AxonRuntime("test_release_server")
+    server.start()
+    server.register_function(
+        _store_then_release_input_func,
+        201,
+        from_dlpack_fn=np.from_dlpack,
+    )
+
+    client = axon.AxonRuntime("test_release_client")
+    client.start_client()
+    await client.connect_endpoint_async(
+        server.get_local_address(), "test_release_server"
+    )
+
+    try:
+        a = np.array([3.0, 4.0, 5.0, 6.0], dtype=np.float64)
+
+        result = await client.invoke(
+            a,
+            worker_name="test_release_server",
+            session_id=0,
+            function=201,
+            from_dlpack_fn=np.from_dlpack,
+        )
+
+        assert result == int(np.sum(a))
+        assert _released_input_tensor is None
+        assert _released_input_tensor_ref is not None
+        assert await _wait_for_object_release(_released_input_tensor_ref)
+    finally:
+        _released_input_tensor = None
+        _released_input_tensor_ref = None
         try:
             client.stop()
             server.stop()

--- a/axon/python/tests/test_register_function.py
+++ b/axon/python/tests/test_register_function.py
@@ -127,7 +127,9 @@ def test_register_function_invalid_untyped_list():
         return 1
 
     with create_server("test_worker_invalid_list") as runtime:
-        with pytest.raises(TypeError, match="Unsupported or missing type annotation"):
+        with pytest.raises(
+            TypeError, match="List without type argument is not supported"
+        ):
             runtime.register_function(
                 callable=invalid_list,
                 function_id=7,
@@ -200,7 +202,7 @@ def test_register_function_invalid_list_list_str():
         return 1
 
     with create_server("test_worker_nested_str") as runtime:
-        with pytest.raises(TypeError, match="Unsupported or missing type annotation"):
+        with pytest.raises(TypeError, match="Unsupported inner element type"):
             runtime.register_function(
                 callable=nested_str_func,
                 function_id=203,
@@ -228,7 +230,9 @@ def test_register_function_invalid_list_list_untyped():
         return 1
 
     with create_server("test_worker_nested_untyped") as runtime:
-        with pytest.raises(TypeError, match="Unsupported or missing type annotation"):
+        with pytest.raises(
+            TypeError, match="requires explicit element type annotation"
+        ):
             runtime.register_function(
                 callable=untyped_nested,
                 function_id=205,

--- a/ucx_context/ucx_context_data_test.cpp
+++ b/ucx_context/ucx_context_data_test.cpp
@@ -82,5 +82,50 @@ TEST_F(UcxBufferTest, ThrowsOnSizeMismatch) {
   EXPECT_THROW(std::move(buffer).to_buffer_vec(sizes), std::length_error);
 }
 
+TEST_F(UcxBufferTest, MoveWithOwnBufferTruePreservesReleaseCallback) {
+  int release_count = 0;
+  auto* external = new uint8_t[16];
+
+  {
+    UcxBuffer buffer(
+      *mr_, ucx_memory_type::HOST, external, 16, nullptr, true,
+      [&release_count](void* ptr) {
+        ++release_count;
+        delete[] static_cast<uint8_t*>(ptr);
+      });
+
+    auto moved = UcxBuffer(std::move(buffer), true);
+    EXPECT_EQ(buffer.data(), nullptr);
+    EXPECT_FALSE(buffer.own_buffer());
+    EXPECT_EQ(moved.data(), external);
+    EXPECT_TRUE(moved.own_buffer());
+  }
+
+  EXPECT_EQ(release_count, 1);
+}
+
+TEST_F(UcxBufferTest, MoveWithOwnBufferFalseSuppressesReleaseCallback) {
+  int release_count = 0;
+  auto* external = new uint8_t[16];
+
+  {
+    UcxBuffer buffer(
+      *mr_, ucx_memory_type::HOST, external, 16, nullptr, true,
+      [&release_count](void* ptr) {
+        ++release_count;
+        delete[] static_cast<uint8_t*>(ptr);
+      });
+
+    auto moved = UcxBuffer(std::move(buffer), false);
+    EXPECT_EQ(buffer.data(), nullptr);
+    EXPECT_FALSE(buffer.own_buffer());
+    EXPECT_EQ(moved.data(), external);
+    EXPECT_FALSE(moved.own_buffer());
+  }
+
+  EXPECT_EQ(release_count, 0);
+  delete[] external;
+}
+
 }  // namespace ucxx
 }  // namespace eux


### PR DESCRIPTION
Root cause: `TensorMetaToDlpack` constructed the owning `shared_ptr<UcxBuffer>` with `own_buffer=false`, which suppressed the release callback on destruction and caused use-after-free when a DLPack tensor outlived its underlying UCX buffer.

- Fix `own_buffer=false` → `true` in `TensorMetaToDlpack` so the release callback fires correctly when the exported DLPack tensor is destroyed
- Add Python bindings for `UcxMemoryResourceManager` and `DefaultUcxMemoryResourceManager` (`bindings_memory_resource.cpp/hpp`) so the resource manager lifetime can be controlled from Python
- Extend `AxonRuntime.__init__` binding to accept an optional `resource_manager` argument; wrap the Python object in a `shared_ptr` with a custom no-op deleter that holds a `nb::object` ref so that runtime can access to the memory resourse.
- Create a package-level `_default_resource_manager` singleton in `axon/__init__.py` and subclass `AxonRuntime` to auto-inject it, ensuring the manager outlives all runtimes and tensors within a session
- Update stale error-message assertions in `test_register_function.py` to match the more specific messages now emitted by the type-checking layer