### PR TITLE
[Deps/Fix] Update dependencies for GCC15 and fix memory leak on interpreter shutdown

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 build --cxxopt=-std=c++23
 # GNU17 For C Project
 build --conlyopt=-std=gnu17
+build --host_conlyopt=-std=gnu17
 
 # Convenient flag shortcuts.
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ ucx_deps = use_extension("//third_party/openucx:extensions.bzl", "openucx_depend
 # ucx_deps.ucx_library(name = "ucx", ucx_path = "/opt/nvidia/hpc_sdk/Linux_x86_64/2024/comm_libs/12.5/hpcx/latest/ucx/")  # A local UCX path
 ucx_deps.ucx_git(
     name = "ucx",
-    tag = "v1.18.1",
+    tag = "v1.20.0",
 )
 use_repo(ucx_deps, "ucx")
 

--- a/axon/python/src/bindings_runtime.cpp
+++ b/axon/python/src/bindings_runtime.cpp
@@ -166,12 +166,14 @@ void RegisterRuntime(nb::module_& m) {
         auto mr = std::shared_ptr<ucxx::UcxMemoryResourceManager>(
           raw, [kept_alive = std::move(kept_alive)](
                  ucxx::UcxMemoryResourceManager*) mutable {
-            if (!Py_IsInitialized()) {
-              kept_alive.release();
-              return;
+            if (Py_IsInitialized()) {
+              nb::gil_scoped_acquire gil;
             }
-            nb::gil_scoped_acquire gil;
-            kept_alive = nb::object{};
+            // Here, when the interpreter is shuted down before
+            // `AxonRuntime.stop` is called, the GIL can't be held any more but
+            // the CPython object model still exist so we simply decrease the
+            // ref count by one.
+            Py_DECREF(kept_alive.ptr());
           });
         new (self) axon::AxonRuntime(
           std::move(mr), worker_name, thread_pool_size,
@@ -333,66 +335,70 @@ void RegisterRuntime(nb::module_& m) {
         self.ConnectEndpointAsync(std::move(ucp_address), worker_name);
 
       // Spawn task on the client async scope
-      self.SpawnClientTask(unifex::on(
-        self.GetTimeContextScheduler(),
-        std::move(sender)
-          | unifex::then(
-            [future_ptr, &wake_manager](
-              std::expected<uint64_t, axon::errors::AxonErrorContext>
-                result) mutable {
-              if (result.has_value()) {
-                wake_manager.Enqueue(pro::make_proxy<python::TaskFacade>(
-                  [future_ptr, value = result.value()]() mutable {
-                    nb::object future = nb::steal<nb::object>(future_ptr);
-                    future.attr("set_result")(nb::cast(value));
-                  }));
-              } else {
-                const auto& error_ctx = result.error();
-                std::string error_msg = python::BuildErrorMessageFromContext(
-                  error_ctx, "Connection failed");
-                wake_manager.Enqueue(pro::make_proxy<python::TaskFacade>(
-                  [future_ptr, error_msg = std::move(error_msg)]() mutable {
-                    nb::object future = nb::steal<nb::object>(future_ptr);
-                    python::SetFutureException(future, error_msg);
-                  }));
-              }
-            })
-          | unifex::upon_error([future_ptr, &wake_manager](auto&& error) {
-              using ErrorType = std::decay_t<decltype(error)>;
-              constexpr bool is_axon_error_context =
-                std::is_same_v<ErrorType, axon::errors::AxonErrorContext>;
-              constexpr bool is_exception_ptr =
-                std::is_same_v<ErrorType, std::exception_ptr>;
-
-              std::string error_msg = "Unknown error in connection";
-
-              if constexpr (is_axon_error_context) {
-                error_msg = python::BuildErrorMessageFromContext(
-                  error, "Connection failed");
-              } else if constexpr (is_exception_ptr) {
-                try {
-                  std::rethrow_exception(error);
-                } catch (const axon::errors::AxonErrorException& e) {
-                  error_msg = python::BuildErrorMessageFromContext(
-                    e.context(), "Connection failed");
-                } catch (const rpc::RpcException& e) {
-                  std::string_view error_msg_view = e.what();
-                  if (!error_msg_view.empty()) {
-                    error_msg = error_msg_view;
-                  } else {
-                    error_msg = "RPC error: " + e.code().message();
-                  }
-                } catch (const std::exception& e) {
-                  error_msg = e.what();
+      self.SpawnClientTask(
+        unifex::on(
+          self.GetTimeContextScheduler(),
+          std::move(sender)
+            | unifex::then(
+              [future_ptr, &wake_manager](
+                std::expected<uint64_t, axon::errors::AxonErrorContext>
+                  result) mutable {
+                if (result.has_value()) {
+                  wake_manager.Enqueue(
+                    pro::make_proxy<python::TaskFacade>(
+                      [future_ptr, value = result.value()]() mutable {
+                        nb::object future = nb::steal<nb::object>(future_ptr);
+                        future.attr("set_result")(nb::cast(value));
+                      }));
+                } else {
+                  const auto& error_ctx = result.error();
+                  std::string error_msg = python::BuildErrorMessageFromContext(
+                    error_ctx, "Connection failed");
+                  wake_manager.Enqueue(
+                    pro::make_proxy<python::TaskFacade>(
+                      [future_ptr, error_msg = std::move(error_msg)]() mutable {
+                        nb::object future = nb::steal<nb::object>(future_ptr);
+                        python::SetFutureException(future, error_msg);
+                      }));
                 }
-              }
+              })
+            | unifex::upon_error([future_ptr, &wake_manager](auto&& error) {
+                using ErrorType = std::decay_t<decltype(error)>;
+                constexpr bool is_axon_error_context =
+                  std::is_same_v<ErrorType, axon::errors::AxonErrorContext>;
+                constexpr bool is_exception_ptr =
+                  std::is_same_v<ErrorType, std::exception_ptr>;
 
-              wake_manager.Enqueue(pro::make_proxy<python::TaskFacade>(
-                [future_ptr, error_msg = std::move(error_msg)]() mutable {
-                  nb::object future = nb::steal<nb::object>(future_ptr);
-                  python::SetFutureException(future, error_msg);
-                }));
-            })));
+                std::string error_msg = "Unknown error in connection";
+
+                if constexpr (is_axon_error_context) {
+                  error_msg = python::BuildErrorMessageFromContext(
+                    error, "Connection failed");
+                } else if constexpr (is_exception_ptr) {
+                  try {
+                    std::rethrow_exception(error);
+                  } catch (const axon::errors::AxonErrorException& e) {
+                    error_msg = python::BuildErrorMessageFromContext(
+                      e.context(), "Connection failed");
+                  } catch (const rpc::RpcException& e) {
+                    std::string_view error_msg_view = e.what();
+                    if (!error_msg_view.empty()) {
+                      error_msg = error_msg_view;
+                    } else {
+                      error_msg = "RPC error: " + e.code().message();
+                    }
+                  } catch (const std::exception& e) {
+                    error_msg = e.what();
+                  }
+                }
+
+                wake_manager.Enqueue(
+                  pro::make_proxy<python::TaskFacade>(
+                    [future_ptr, error_msg = std::move(error_msg)]() mutable {
+                      nb::object future = nb::steal<nb::object>(future_ptr);
+                      python::SetFutureException(future, error_msg);
+                    }));
+              })));
       return future;
     },
     nb::arg("ucp_address"), nb::arg("worker_name"));
@@ -457,14 +463,15 @@ void RegisterRuntime(nb::module_& m) {
       if (
         !memory_policy_factory.is_none() && !tensor_param_indices.empty()
         && from_dlpack_fn.is_none()) {
-        throw std::runtime_error(std::format(
-          "Function '{}' has tensor parameters and custom memory_policy is "
-          "set, but from_dlpack_fn is not provided. "
-          "from_dlpack_fn is required to handle UCX eager path where data "
-          "arrives pre-allocated in host memory and custom_memory_policy "
-          "is not invoked. Please provide from_dlpack_fn (e.g., "
-          "numpy.from_dlpack, torch.from_dlpack, jax.dlpack.from_dlpack).",
-          function_name));
+        throw std::runtime_error(
+          std::format(
+            "Function '{}' has tensor parameters and custom memory_policy is "
+            "set, but from_dlpack_fn is not provided. "
+            "from_dlpack_fn is required to handle UCX eager path where data "
+            "arrives pre-allocated in host memory and custom_memory_policy "
+            "is not invoked. Please provide from_dlpack_fn (e.g., "
+            "numpy.from_dlpack, torch.from_dlpack, jax.dlpack.from_dlpack).",
+            function_name));
       }
 
       // Build from_dlpack_fn vectors if user provided one
@@ -749,14 +756,15 @@ void RegisterRuntime(nb::module_& m) {
       if (
         !memory_policy_factory.is_none()
         && !sig_info.tensor_param_indices.empty() && from_dlpack_fn.is_none()) {
-        throw std::runtime_error(std::format(
-          "Function '{}' has tensor parameters and custom memory_policy is "
-          "set, but from_dlpack_fn is not provided. "
-          "from_dlpack_fn is required to handle UCX eager path where data "
-          "arrives pre-allocated in host memory and custom_memory_policy "
-          "is not invoked. Please provide from_dlpack_fn (e.g., "
-          "numpy.from_dlpack, torch.from_dlpack, jax.dlpack.from_dlpack).",
-          function_name));
+        throw std::runtime_error(
+          std::format(
+            "Function '{}' has tensor parameters and custom memory_policy is "
+            "set, but from_dlpack_fn is not provided. "
+            "from_dlpack_fn is required to handle UCX eager path where data "
+            "arrives pre-allocated in host memory and custom_memory_policy "
+            "is not invoked. Please provide from_dlpack_fn (e.g., "
+            "numpy.from_dlpack, torch.from_dlpack, jax.dlpack.from_dlpack).",
+            function_name));
       }
 
       // Override from_dlpack_fn callables if user provided one
@@ -880,9 +888,10 @@ void RegisterRuntime(nb::module_& m) {
            result_handler = std::move(result_handler)](auto&& payload) mutable {
             rpc::RpcRequestHeader& header_ref =
               nb::cast<rpc::RpcRequestHeader&>(request_header_obj);
-            self.SpawnClientTask(python::InvokeRpcWithCustomMemory(
-              self, worker_name, std::move(header_ref), std::move(payload),
-              memory_policy_factory, std::move(result_handler)));
+            self.SpawnClientTask(
+              python::InvokeRpcWithCustomMemory(
+                self, worker_name, std::move(header_ref), std::move(payload),
+                memory_policy_factory, std::move(result_handler)));
           };
         dispatch_rpc(std::move(handler));
       } else {
@@ -891,9 +900,10 @@ void RegisterRuntime(nb::module_& m) {
                           std::move(result_handler)](auto&& payload) mutable {
           rpc::RpcRequestHeader& header_ref =
             nb::cast<rpc::RpcRequestHeader&>(request_header_obj);
-          self.SpawnClientTask(python::InvokeRpcWithHostPolicy(
-            self, worker_name, std::move(header_ref), std::move(payload),
-            std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithHostPolicy(
+              self, worker_name, std::move(header_ref), std::move(payload),
+              std::move(result_handler)));
         };
         dispatch_rpc(std::move(handler));
       }
@@ -969,37 +979,44 @@ void RegisterRuntime(nb::module_& m) {
       // Dispatch based on tensor count
       if (ctx.tensor_count() == 0) {
         if (use_custom_memory) {
-          self.SpawnClientTask(python::InvokeRpcWithCustomMemory(
-            self, worker_name, std::move(request_header), std::monostate{},
-            memory_policy_factory, std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithCustomMemory(
+              self, worker_name, std::move(request_header), std::monostate{},
+              memory_policy_factory, std::move(result_handler)));
         } else {
-          self.SpawnClientTask(python::InvokeRpcWithHostPolicy(
-            self, worker_name, std::move(request_header), std::monostate{},
-            std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithHostPolicy(
+              self, worker_name, std::move(request_header), std::monostate{},
+              std::move(result_handler)));
         }
       } else if (ctx.tensor_count() == 1) {
         // Use cached data to create buffer (no repeated ExtractDlpackTensor)
         ucxx::UcxBuffer buffer = ctx.to_ucx_buffer(mr);
         if (use_custom_memory) {
-          self.SpawnClientTask(python::InvokeRpcWithCustomMemory(
-            self, worker_name, std::move(request_header), std::move(buffer),
-            memory_policy_factory, std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithCustomMemory(
+              self, worker_name, std::move(request_header), std::move(buffer),
+              memory_policy_factory, std::move(result_handler)));
         } else {
-          self.SpawnClientTask(python::InvokeRpcWithHostPolicy(
-            self, worker_name, std::move(request_header), std::move(buffer),
-            std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithHostPolicy(
+              self, worker_name, std::move(request_header), std::move(buffer),
+              std::move(result_handler)));
         }
       } else {
         // Vector path
         ucxx::UcxBufferVec buffer_vec = ctx.to_ucx_buffer_vec(mr);
         if (use_custom_memory) {
-          self.SpawnClientTask(python::InvokeRpcWithCustomMemory(
-            self, worker_name, std::move(request_header), std::move(buffer_vec),
-            memory_policy_factory, std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithCustomMemory(
+              self, worker_name, std::move(request_header),
+              std::move(buffer_vec), memory_policy_factory,
+              std::move(result_handler)));
         } else {
-          self.SpawnClientTask(python::InvokeRpcWithHostPolicy(
-            self, worker_name, std::move(request_header), std::move(buffer_vec),
-            std::move(result_handler)));
+          self.SpawnClientTask(
+            python::InvokeRpcWithHostPolicy(
+              self, worker_name, std::move(request_header),
+              std::move(buffer_vec), std::move(result_handler)));
         }
       }
 

--- a/third_party/libunifex/repositories.bzl
+++ b/third_party/libunifex/repositories.bzl
@@ -8,6 +8,6 @@ def libunifex_repo():
     new_git_repository(
         name = "unifex",
         remote = "https://github.com/facebookexperimental/libunifex.git",
-        commit = "75180df5f87f2f7f86c0b2137fa84c95849f2240",
+        commit = "8c5fa963e0198db303f816de33790f03fbca7f45",
         build_file = "//third_party/libunifex:BUILD.bazel",
     )

--- a/third_party/openucx/BUILD.bazel
+++ b/third_party/openucx/BUILD.bazel
@@ -8,6 +8,44 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "with_ib",
+    values = {
+        "define": "ucx_with_ib=true",
+    },
+)
+
+IB_CONFIGURE_OPTIONS = [
+    "--with-rc",
+    "--with-ud",
+    "--with-dc",
+    "--with-ib-hw-tm",
+    "--with-dm",
+    "--with-mlx5=guess",
+    # "--with-verbs=guess",  # Seems OpenFabrics verbs not compatible with mlx5?
+    "--with-rdmacm=guess",
+]
+
+NO_IB_CONFIGURE_OPTIONS = [
+    "--without-verbs",
+    "--without-mlx5",
+    "--without-rdmacm",
+]
+
+IB_SHARED_LIBS = [
+    "libuct_ib.so",
+    "libuct_ib.so.0",
+    "libuct_ib.so.0.0.0",
+    "libuct_ib_mlx5.so",
+    "libuct_ib_mlx5.so.0",
+    "libuct_ib_mlx5.so.0.0.0",
+]
+
+IB_STATIC_LIBS = [
+    "libuct_ib.a",
+    "libuct_ib_mlx5.a",
+]
+
 filegroup(
     name = "all_srcs",
     srcs = glob(["**"]),
@@ -31,28 +69,22 @@ configure_make(
         "--enable-compiler-opt",
         "--enable-optimizations",
         "--enable-cma",
-        "--with-rc",
-        "--with-ud",
-        "--with-dc",
-        "--with-ib-hw-tm",
-        "--with-dm",
         "--enable-tuning",
         "--with-fuse3=guess",
         "--with-mad=guess",
         "--with-gdrcopy=guess",
-        "--with-mlx5=guess",
-        # "--with-verbs=guess",  # Seems OpenFabrics verbs not compatible with mlx5?
-        "--with-rdmacm=guess",
         "--with-knem=guess",
         "--with-xpmem=guess",
         "--with-java=no",
         "--with-go=no",
     ] + select({
+        ":with_ib": IB_CONFIGURE_OPTIONS,
+        "//conditions:default": NO_IB_CONFIGURE_OPTIONS,
+    }) + select({
         "@rules_cuda//cuda:is_enabled": [
             "--with-cuda",
         ],
-        "//conditions:default": [
-        ],
+        "//conditions:default": [],
     }),
     copts = [
         "-Wno-error",
@@ -89,13 +121,10 @@ configure_make(
         "libuct_cma.so",
         "libuct_cma.so.0",
         "libuct_cma.so.0.0.0",
-        "libuct_ib.so",
-        "libuct_ib.so.0",
-        "libuct_ib.so.0.0.0",
-        "libuct_ib_mlx5.so",
-        "libuct_ib_mlx5.so.0",
-        "libuct_ib_mlx5.so.0.0.0",
     ] + select({
+        ":with_ib": IB_SHARED_LIBS,
+        "//conditions:default": [],
+    }) + select({
         "@rules_cuda//cuda:is_enabled": [
             # ucx directory prefix has been removed
             "libucm_cuda.so",
@@ -105,8 +134,7 @@ configure_make(
             "libuct_cuda.so.0",
             "libuct_cuda.so.0.0.0",
         ],
-        "//conditions:default": [
-        ],
+        "//conditions:default": [],
     }),
     out_static_libs = [
         "libucm.a",
@@ -116,23 +144,22 @@ configure_make(
         "libuct.a",
         # ucx directory prefix has been removed
         "libuct_cma.a",
-        "libuct_ib.a",
-        "libuct_ib_mlx5.a",
     ] + select({
+        ":with_ib": IB_STATIC_LIBS,
+        "//conditions:default": [],
+    }) + select({
         "@rules_cuda//cuda:is_enabled": [
             "libucm_cuda.a",
             "libuct_cuda.a",
         ],
-        "//conditions:default": [
-        ],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_cuda//cuda:is_enabled": [
             "@rules_cuda//cuda:runtime",
         ],
-        "//conditions:default": [
-        ],
+        "//conditions:default": [],
     }),
 )
 


### PR DESCRIPTION
Deps:
- Add --host_conlyopt=-std=gnu17 to .bazelrc for host C compilation
- Bump UCX from v1.18.1 to v1.20.0
- Update libunifex to commit 8c5fa963 for GCC15 support
- Make UCX InfiniBand support opt-in with --define=ucx_with_ib=true so default builds do not require verbs/mlx5/rdmacm libraries, while still listing the IB outputs when enabled.

Fix (regression from 7b7708a):
- `kept_alive.release()` on `!Py_IsInitialized()` dropped nanobind ownership without decrementing the CPython refcount, leaking the Python object. The CPython object model is still live during interpreter shutdown, so `Py_DECREF` is safe to call directly; the GIL is only acquired when the interpreter is fully initialized.