### PR TITLE
[Deps/Fix] Update dependencies for GCC15 and fix memory leak on interpreter shutdown

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 build --cxxopt=-std=c++23
 # GNU17 For C Project
 build --conlyopt=-std=gnu17
+build --host_conlyopt=-std=gnu17
 
 # Convenient flag shortcuts.
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ ucx_deps = use_extension("//third_party/openucx:extensions.bzl", "openucx_depend
 # ucx_deps.ucx_library(name = "ucx", ucx_path = "/opt/nvidia/hpc_sdk/Linux_x86_64/2024/comm_libs/12.5/hpcx/latest/ucx/")  # A local UCX path
 ucx_deps.ucx_git(
     name = "ucx",
-    tag = "v1.18.1",
+    tag = "v1.20.0",
 )
 use_repo(ucx_deps, "ucx")
 

--- a/axon/python/BUILD.bazel
+++ b/axon/python/BUILD.bazel
@@ -575,13 +575,13 @@ cc_binary(
     ],
 )
 
-# Create a symlink/copy with the correct name for Python import
-# nanobind expects the module name to match the .so filename
-# Bazel generates libaxon_python_runtime.so, we copy it to axon/axon.so
+# Create a copy with the correct name for Python import.
+# Keep it next to axon_python_runtime so Bazel's generated RUNPATH entries
+# still point at bazel-bin/_solib_k8 when importing from the source tree.
 genrule(
     name = "axon_python_lib",
     srcs = [":axon_python_runtime"],
-    outs = ["axon/axon.so"],
+    outs = ["axon.so"],
     cmd = "cp $(location :axon_python_runtime) $@",
     visibility = ["//visibility:public"],
 )

--- a/axon/python/axon/__init__.py
+++ b/axon/python/axon/__init__.py
@@ -84,12 +84,13 @@ def _find_and_load_module():
 
     # Search in current directory and common Bazel output locations
     search_paths = [
-        current_dir,  # axon/ (source location)
+        current_dir,  # axon/ (installed wheel/source location)
+        current_dir.parent.parent.parent / "bazel-bin" / "axon" / "python",
         current_dir.parent.parent.parent
         / "bazel-bin"
         / "axon"
         / "python"
-        / "axon",  # bazel-bin output
+        / "axon",  # legacy bazel-bin output
     ]
 
     # Also check runfiles if running under Bazel
@@ -98,6 +99,7 @@ def _find_and_load_module():
         search_paths.insert(
             0, runfiles_dir / "execution_ucx" / "axon" / "python" / "axon"
         )
+        search_paths.insert(0, runfiles_dir / "execution_ucx" / "axon" / "python")
         search_paths.insert(0, runfiles_dir)
 
     # Try to find the library

--- a/axon/python/src/bindings_runtime.cpp
+++ b/axon/python/src/bindings_runtime.cpp
@@ -166,12 +166,17 @@ void RegisterRuntime(nb::module_& m) {
         auto mr = std::shared_ptr<ucxx::UcxMemoryResourceManager>(
           raw, [kept_alive = std::move(kept_alive)](
                  ucxx::UcxMemoryResourceManager*) mutable {
-            if (!Py_IsInitialized()) {
+            if (Py_IsInitialized()) {
+              nb::gil_scoped_acquire gil;
+              kept_alive = nb::object{};
+            } else {
+              // Here, when the interpreter is shut down before
+              // `AxonRuntime.stop` is called, the GIL can't be held any more
+              // but the CPython object model still exists so we simply decrease
+              // the ref count by one.
+              Py_XDECREF(kept_alive.ptr());
               kept_alive.release();
-              return;
             }
-            nb::gil_scoped_acquire gil;
-            kept_alive = nb::object{};
           });
         new (self) axon::AxonRuntime(
           std::move(mr), worker_name, thread_pool_size,

--- a/third_party/libunifex/repositories.bzl
+++ b/third_party/libunifex/repositories.bzl
@@ -8,6 +8,6 @@ def libunifex_repo():
     new_git_repository(
         name = "unifex",
         remote = "https://github.com/facebookexperimental/libunifex.git",
-        commit = "75180df5f87f2f7f86c0b2137fa84c95849f2240",
+        commit = "8c5fa963e0198db303f816de33790f03fbca7f45",
         build_file = "//third_party/libunifex:BUILD.bazel",
     )


### PR DESCRIPTION
Deps:
- Add --host_conlyopt=-std=gnu17 to .bazelrc for host C compilation
- Bump UCX from v1.18.1 to v1.20.0
- Update libunifex to commit 8c5fa963 for GCC15 support

Fix (regression from 7b7708a):
- `kept_alive.release()` on `!Py_IsInitialized()` dropped nanobind ownership without decrementing the CPython refcount, leaking the Python object. The CPython object model is still live during interpreter shutdown, so `Py_DECREF` is safe to call directly; the GIL is only acquired when the interpreter is fully initialized.