### PR TITLE
[Deps/Fix] Update dependencies for GCC15 and fix memory leak on interpreter shutdown

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 build --cxxopt=-std=c++23
 # GNU17 For C Project
 build --conlyopt=-std=gnu17
+build --host_conlyopt=-std=gnu17
 
 # Convenient flag shortcuts.
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ ucx_deps = use_extension("//third_party/openucx:extensions.bzl", "openucx_depend
 # ucx_deps.ucx_library(name = "ucx", ucx_path = "/opt/nvidia/hpc_sdk/Linux_x86_64/2024/comm_libs/12.5/hpcx/latest/ucx/")  # A local UCX path
 ucx_deps.ucx_git(
     name = "ucx",
-    tag = "v1.18.1",
+    tag = "v1.20.0",
 )
 use_repo(ucx_deps, "ucx")
 

--- a/axon/python/src/bindings_runtime.cpp
+++ b/axon/python/src/bindings_runtime.cpp
@@ -174,8 +174,7 @@ void RegisterRuntime(nb::module_& m) {
               // `AxonRuntime.stop` is called, the GIL can't be held any more
               // but the CPython object model still exists so we simply decrease
               // the ref count by one.
-              Py_XDECREF(kept_alive.ptr());
-              kept_alive.release();
+              Py_XDECREF(kept_alive.release());
             }
           });
         new (self) axon::AxonRuntime(

--- a/axon/python/src/bindings_runtime.cpp
+++ b/axon/python/src/bindings_runtime.cpp
@@ -166,12 +166,17 @@ void RegisterRuntime(nb::module_& m) {
         auto mr = std::shared_ptr<ucxx::UcxMemoryResourceManager>(
           raw, [kept_alive = std::move(kept_alive)](
                  ucxx::UcxMemoryResourceManager*) mutable {
-            if (!Py_IsInitialized()) {
+            if (Py_IsInitialized()) {
+              nb::gil_scoped_acquire gil;
+              kept_alive = nb::object{};
+            } else {
+              // Here, when the interpreter is shut down before
+              // `AxonRuntime.stop` is called, the GIL can't be held any more
+              // but the CPython object model still exists so we simply decrease
+              // the ref count by one.
+              Py_XDECREF(kept_alive.ptr());
               kept_alive.release();
-              return;
             }
-            nb::gil_scoped_acquire gil;
-            kept_alive = nb::object{};
           });
         new (self) axon::AxonRuntime(
           std::move(mr), worker_name, thread_pool_size,

--- a/axon/python/src/bindings_runtime_helpers.hpp
+++ b/axon/python/src/bindings_runtime_helpers.hpp
@@ -127,7 +127,7 @@ void HandleRpcSuccessResult(
 void HandleRpcDone(SharedPyObject future, PythonWakeManager& manager);
 
 // Create error handler for RPC invocation results
-struct CreateRpcErrorHandler {
+struct __attribute__((visibility("hidden"))) CreateRpcErrorHandler {
   SharedPyObject future_;
   PythonWakeManager& manager_;
   mutable bool error_handled_{false};
@@ -169,7 +169,7 @@ struct CreateRpcErrorHandler {
 };
 
 // Create result handler for RPC invocation
-struct CreateRpcResultHandler {
+struct __attribute__((visibility("hidden"))) CreateRpcResultHandler {
   SharedPyObject future_;
   PythonWakeManager& manager_;
   SharedPyObject from_dlpack_;  // GIL-safe wrapper for from_dlpack_fn callable
@@ -333,7 +333,7 @@ inline ArgKind ClassifyArg(const nb::object& obj) {
 
 // Caches DLManagedTensor* and owner to avoid repeated
 // ExtractDlpackTensor calls when both TensorMeta and UcxBuffer are needed.
-struct InvokeContext {
+struct __attribute__((visibility("hidden"))) InvokeContext {
   std::vector<nb::object> tensor_objs;
   std::vector<rpc::utils::TensorMeta> tensor_metas;
   std::vector<DLManagedTensor*> dlm_ptrs;  // Cached DLManagedTensor pointers

--- a/axon/python/src/dlpack_helpers.hpp
+++ b/axon/python/src/dlpack_helpers.hpp
@@ -60,7 +60,7 @@ using TensorMetaVec = rpc::TensorMetaVec;
 // - Minimal overhead: Only creates a small Python object
 // - No locks: Uses atomic flag for thread-safe consumption check
 // - Compatible with all DLPack-compliant frameworks
-class DLPackCapsuleWrapper {
+class __attribute__((visibility("hidden"))) DLPackCapsuleWrapper {
  public:
   DLPackCapsuleWrapper(nb::object capsule, DLDevice device)
     : capsule_(std::move(capsule)), device_(device), consumed_(false) {}

--- a/axon/python/src/python_helpers.cpp
+++ b/axon/python/src/python_helpers.cpp
@@ -174,7 +174,7 @@ static bool IsTensorType(nb::object type) {
               != std::string::npos;
 }
 
-struct AnnotationTypeInfo {
+struct __attribute__((visibility("hidden"))) AnnotationTypeInfo {
   rpc::ParamType param_type;
   std::optional<FunctionSignatureInfo::EncodedElementType> encoded_element_type;
   nb::object nested_tensor_type;

--- a/axon/python/src/python_wake_manager.hpp
+++ b/axon/python/src/python_wake_manager.hpp
@@ -60,7 +60,7 @@ struct TaskFacade : pro::facade_builder  //
  * triggered). Python can wait on the eventfd (e.g., with io_uring) and call
  * ProcessQueue to execute all pending tasks with the GIL held.
  */
-class PythonWakeManager {
+class __attribute__((visibility("hidden"))) PythonWakeManager {
  public:
   using Scheduler = decltype(std::declval<unifex::timed_single_thread_context>()
                                .get_scheduler());

--- a/third_party/libunifex/repositories.bzl
+++ b/third_party/libunifex/repositories.bzl
@@ -8,6 +8,6 @@ def libunifex_repo():
     new_git_repository(
         name = "unifex",
         remote = "https://github.com/facebookexperimental/libunifex.git",
-        commit = "75180df5f87f2f7f86c0b2137fa84c95849f2240",
+        commit = "8c5fa963e0198db303f816de33790f03fbca7f45",
         build_file = "//third_party/libunifex:BUILD.bazel",
     )


### PR DESCRIPTION
Deps:
- Add --host_conlyopt=-std=gnu17 to .bazelrc for host C compilation
- Bump UCX from v1.18.1 to v1.20.0
- Update libunifex to commit 8c5fa963 for GCC15 support

Fix (regression from 7b7708a):
- `kept_alive.release()` on `!Py_IsInitialized()` dropped nanobind ownership without decrementing the CPython refcount, leaking the Python object. The CPython object model is still live during interpreter shutdown, so `Py_DECREF` is safe to call directly; the GIL is only acquired when the interpreter is fully initialized.
- Fix some symbol visibility warnings.